### PR TITLE
Fix crash upon saving

### DIFF
--- a/level_info_editor.py
+++ b/level_info_editor.py
@@ -203,14 +203,14 @@ class LevelInfoFile():
             world_data.extend(struct.pack('>I', num))
 
             # Add data to world_data for each world half
-            for exists, name in zip((world.has_left, world.has_right), ('L', 'R')):
+            for exists, name in zip((world.has_left, world.has_right), ('left', 'right')):
                 if not exists: continue
-                w_name = getattr(world, f'{name}Name')
+                w_name = getattr(world, f'name_{name}')
                 world_data.extend(LEVEL_ENTRY_STRUCT.pack(
                     98, 98,  # filename: 98-98
-                    world.world_number, (101 if name == 'R' else 100),  # display name: WN-100
+                    world.world_number, (101 if name == 'right' else 100),  # display name: WN-100
                     len(w_name),
-                    (0x400 if name == 'R' else 0),
+                    (0x400 if name == 'right' else 0),
                     current_text_offs))
 
                 current_text_offs += len(w_name) + 1


### PR DESCRIPTION
A refactor done for 1.6 ended up changing some attribute names in the WorldInfo class. However, in the saving routine, a call to getattr that attempts to access those attributes was not updated to compensate, and as such, saving crashes the entire program with an exception.

Relatedly, this same change broke the data in the output file that differentiates between the first and second parts of each world (each part of the world - even the second half - is marked as the "first half" instead).

This PR fixes these issues (saving Newer's LevelInfo.bin successfully creates an identical output file).